### PR TITLE
Set URL duration default to empty string and add typing info to API service

### DIFF
--- a/src/components/UrlForm/UrlForm.tsx
+++ b/src/components/UrlForm/UrlForm.tsx
@@ -10,7 +10,7 @@ const units = ['minutes', 'days', 'months']
 
 interface State {
   url: string
-  duration: number
+  duration: number | string
   unit: string
   passcode: string
 }
@@ -22,7 +22,7 @@ interface Props {
 class UrlForm extends React.Component<Props, State> {
   private initialState = {
     url: '',
-    duration: NaN,
+    duration: '',
     unit: units[0],
     passcode: ''
   }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,33 @@
 import fetch from 'isomorphic-unfetch'
 
-export const encodeUrl = async payload => {
+interface EncodeUrlPayload {
+  url: string
+  duration?: number | string
+  unit?: string
+  passcode?: string
+}
+
+interface EncodeUrlResponse {
+  hash: string
+  expires?: number | null
+}
+
+interface DecodeUrlError {
+  message?: string
+  hasPasscode?: boolean
+}
+
+interface DecodeUrlResponse {
+  id: number
+  created: Date
+  url: string
+  expires: Date
+  passcode: string
+}
+
+export const encodeUrl = async (
+  payload: EncodeUrlPayload
+): Promise<EncodeUrlResponse> => {
   const res = await fetch('/api/url', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -9,12 +36,22 @@ export const encodeUrl = async payload => {
   return res.json()
 }
 
-export const decodeUrl = async ({ hash }) => {
+export const decodeUrl = async ({
+  hash
+}: {
+  hash: string
+}): Promise<DecodeUrlResponse | DecodeUrlError> => {
   const res = await fetch(`/api/url/${hash}`)
   return res.json()
 }
 
-export const attemptPasscode = async ({ hash, passcode }) => {
+export const attemptPasscode = async ({
+  hash,
+  passcode
+}: {
+  hash: string
+  passcode: string
+}): Promise<DecodeUrlResponse | DecodeUrlError> => {
   const res = await fetch(`/api/url/${hash}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
* The duration value must be either a number or string to be a valid value for the input element's
value attribute
* Add typing information for the client API services file to remove lint warnings